### PR TITLE
2.0.1

### DIFF
--- a/scientiamobile/wmclient/wmclient.go
+++ b/scientiamobile/wmclient/wmclient.go
@@ -74,7 +74,7 @@ type WmClient struct {
 
 // GetAPIVersion returns the version number of WM Client API
 func GetAPIVersion() string {
-	return "2.0.0"
+	return "2.0.1"
 }
 
 // creates a new http.Client with the specified timeouts

--- a/scientiamobile/wmclient/wmclient_test.go
+++ b/scientiamobile/wmclient/wmclient_test.go
@@ -484,11 +484,11 @@ func TestLookupDeviceEmptyUseragent(t *testing.T) {
 	client := createTestClient(t)
 	jsonData, err := client.LookupUserAgent("")
 	require.NotNil(t, jsonData)
-	require.NotNil(t, err)
+	require.Nil(t, err)
 	did := jsonData.Capabilities
-	require.Nil(t, did)
-	require.True(t, len(did) == 0)
-	require.True(t, strings.Contains(err.Error(), "No User-Agent"))
+	require.NotNil(t, did)
+	require.True(t, len(did) > 0)
+	require.Equal(t, "generic", jsonData.Capabilities["wurfl_id"])
 	require.True(t, len(jsonData.APIVersion) > 0)
 	client.DestroyConnection()
 }
@@ -607,11 +607,11 @@ func TestLookupRequestWithNoHeaders(t *testing.T) {
 	jsonData, err := client.LookupRequest(*request)
 
 	require.NotNil(t, jsonData)
-	require.NotNil(t, err)
+	require.Nil(t, err)
 	did := jsonData.Capabilities
-	require.Nil(t, did)
+	require.NotNil(t, did)
 	require.True(t, len(jsonData.Error) == 0)
-	require.True(t, strings.Contains(err.Error(), "No User-Agent"))
+	require.Equal(t, "generic", jsonData.Capabilities["wurfl_id"])
 	client.DestroyConnection()
 }
 


### PR DESCRIPTION
This PR modifies tests to adapt them to new server behavior of not returning error on empty user-agent or header. It also adapts test to run with different server configurations.