### PR TITLE
WPC-215: added method LookupHeaders(map[string]string) to client. Add…

### DIFF
--- a/scientiamobile/wmclient/wmclient.go
+++ b/scientiamobile/wmclient/wmclient.go
@@ -74,7 +74,7 @@ type WmClient struct {
 
 // GetAPIVersion returns the version number of WM Client API
 func GetAPIVersion() string {
-	return "2.0.1"
+	return "2.1.0"
 }
 
 // creates a new http.Client with the specified timeouts


### PR DESCRIPTION
- This PR adds a method lookupHeaders(map[string]string) that is useful when the Request struct is not available (ie: when reading  input data for device detection from log files or servers).

Build and unit tests:
https://teamcity.scientiamobile.com/viewLog.html?buildId=151833&buildTypeId=WurflMicroservice20_WmClient_Golang_WmClientGolangGo113debian9BuildTestAndPackWurflIoPublicRepo&tab=testsInfo