### PR TITLE
2.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### 2.1.1
+- Fixed issue in `LookupHeaders(map[string]string` when correct headers are passed using mixed case keys (ie: "UsEr-Agent")
+
 ### 2.1.0
 - Added `LookupHeaders(map[string]string` method to API
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ This is the GO Client API for accessing the WURFL Microservice. The API is relea
 
 - WURFL Microservice for AWS: https://www.scientiamobile.com/products/wurfl-device-detection-microservice-aws/ 
 
+- WURFL Microservice for Azure: https://www.scientiamobile.com/products/wurfl-microservice-for-azure/
+
+- WURFL Microservice for Google Cloud Platform: https://www.scientiamobile.com/products/wurfl-microservice-for-gcp/
+
 
 
 Example api usage :

--- a/scientiamobile/wmclient/wmclient.go
+++ b/scientiamobile/wmclient/wmclient.go
@@ -26,6 +26,7 @@ import (
 	"net"
 	"net/http"
 	"sort"
+	"strings"
 	"sync"
 	"time"
 
@@ -74,7 +75,7 @@ type WmClient struct {
 
 // GetAPIVersion returns the version number of WM Client API
 func GetAPIVersion() string {
-	return "2.1.0"
+	return "2.1.1"
 }
 
 // creates a new http.Client with the specified timeouts
@@ -324,10 +325,16 @@ func (c *WmClient) LookupHeaders(headers map[string]string) (*JSONDeviceData, er
 
 	jrequest := Request{LookupHeaders: make(map[string]string)}
 
+	// first: make all headers lowercase
+	var lowerKeyMap = make(map[string]string)
+	for k, v := range headers {
+		lowerKeyMap[strings.ToLower(k)] = v
+	}
+
 	// copy headers
 	for i := 0; i < len(c.ImportantHeaders); i++ {
 		name := c.ImportantHeaders[i]
-		h := headers[name]
+		h := lowerKeyMap[strings.ToLower(name)]
 		if h != "" {
 			jrequest.LookupHeaders[name] = h
 		}

--- a/scientiamobile/wmclient/wmclient_test.go
+++ b/scientiamobile/wmclient/wmclient_test.go
@@ -629,6 +629,33 @@ func TestLookupHeadersOk(t *testing.T) {
 	client.DestroyConnection()
 }
 
+func TestLookupHeadersWithMixedCase(t *testing.T) {
+	client := createTestClient(t)
+
+	// Let's create test headers
+	var headers = make(map[string]string, 4)
+	headers["X-RequesTed-With"] = "json_client"
+	headers["Content-TYpe"] = "application/json"
+	headers["Accept-EnCoding"] = "gzip, deflate"
+	headers["X-UCBrowsEr-DeVice-UA"] = "Mozilla/5.0 (SAMSUNG; SAMSUNG-GT-S5253/S5253DDJI7; U; Bada/1.0; en-us) AppleWebKit/533.1 (KHTML, like Gecko) Dolfin/2.0 Mobile WQVGA SMM-MMS/1.2.0 OPN-B"
+	headers["UseR-AgEnt"] = "Mozilla/5.0 (Nintendo Switch; WebApplet) AppleWebKit/601.6 (KHTML, like Gecko) NF/4.0.0.5.9 NintendoBrowser/5.1.0.13341"
+
+	var jsonData *JSONDeviceData
+	var derr error
+	jsonData, derr = client.LookupHeaders(headers)
+
+	require.NotNil(t, jsonData)
+	require.Nil(t, derr)
+	did := jsonData.Capabilities
+	require.NotNil(t, did)
+	require.Equal(t, "Samsung", did["brand_name"])
+	require.Equal(t, "GT-S5253", did["model_name"])
+	require.Equal(t, "false", did["is_robot"])
+	require.True(t, len(did) > 0)
+
+	client.DestroyConnection()
+}
+
 func TestLookupHeadersWithNilOrEmptyMap(t *testing.T) {
 	client := createTestClient(t)
 

--- a/scientiamobile/wmclient/wmclient_test.go
+++ b/scientiamobile/wmclient/wmclient_test.go
@@ -656,6 +656,53 @@ func TestLookupHeadersWithMixedCase(t *testing.T) {
 	client.DestroyConnection()
 }
 
+func TestLookupHeadersWithMixedCase_CachedClient(t *testing.T) {
+	client := createTestCachedClient(t)
+
+	// Let's create test headers
+	var headers = make(map[string]string, 4)
+	headers["X-RequesTed-With"] = "json_client"
+	headers["Content-TYpe"] = "application/json"
+	headers["Accept-EnCoding"] = "gzip, deflate"
+	headers["X-UCBrowsEr-DeVice-UA"] = "Mozilla/5.0 (SAMSUNG; SAMSUNG-GT-S5253/S5253DDJI7; U; Bada/1.0; en-us) AppleWebKit/533.1 (KHTML, like Gecko) Dolfin/2.0 Mobile WQVGA SMM-MMS/1.2.0 OPN-B"
+	headers["UseR-AgEnt"] = "Mozilla/5.0 (Nintendo Switch; WebApplet) AppleWebKit/601.6 (KHTML, like Gecko) NF/4.0.0.5.9 NintendoBrowser/5.1.0.13341"
+
+	var jsonData *JSONDeviceData
+	var derr error
+	jsonData, derr = client.LookupHeaders(headers)
+
+	require.NotNil(t, jsonData)
+	require.Nil(t, derr)
+	did := jsonData.Capabilities
+	require.NotNil(t, did)
+	require.Equal(t, "Samsung", did["brand_name"])
+	require.Equal(t, "GT-S5253", did["model_name"])
+	require.Equal(t, "false", did["is_robot"])
+	require.True(t, len(did) > 0)
+	_, c := client.GetActualCacheSizes()
+	require.Equal(t, 1, c)
+
+	// let's retry mixing header case in a different way (now we'll have a cache hit)
+	headers = make(map[string]string, 4)
+	headers["X-ReqUesTed-With"] = "json_client"
+	headers["ConteNt-TYpe"] = "application/json"
+	headers["AccepT-EnCoding"] = "gzip, deflate"
+	headers["X-UCBrOwsEr-DeVice-UA"] = "Mozilla/5.0 (SAMSUNG; SAMSUNG-GT-S5253/S5253DDJI7; U; Bada/1.0; en-us) AppleWebKit/533.1 (KHTML, like Gecko) Dolfin/2.0 Mobile WQVGA SMM-MMS/1.2.0 OPN-B"
+	headers["UseR-AgeNT"] = "Mozilla/5.0 (Nintendo Switch; WebApplet) AppleWebKit/601.6 (KHTML, like Gecko) NF/4.0.0.5.9 NintendoBrowser/5.1.0.13341"
+
+	jsonData, derr = client.LookupHeaders(headers)
+	require.NotNil(t, jsonData)
+	require.Nil(t, derr)
+	did = jsonData.Capabilities
+	require.NotNil(t, did)
+	require.Equal(t, "Samsung", did["brand_name"])
+	// Same value as before, cache has been hit
+	_, c = client.GetActualCacheSizes()
+	require.Equal(t, 1, c)
+
+	client.DestroyConnection()
+}
+
 func TestLookupHeadersWithNilOrEmptyMap(t *testing.T) {
 	client := createTestClient(t)
 


### PR DESCRIPTION
- Fixed issue in `LookupHeaders(map[string]string` when correct headers are passed using mixed case keys (ie: "UsEr-Agent")

- TC build with passing unit test here: https://teamcity.scientiamobile.com/viewLog.html?buildId=152267&buildTypeId=WurflMicroservice20_WmClient_Golang_WmClientGolangGo113debian9BuildTestAndPackWurflIoPublicRepo